### PR TITLE
Grug Far Prefill search with word under cursor not working

### DIFF
--- a/tag-nvim/config/nvim/lua/plugins/grug_far.lua
+++ b/tag-nvim/config/nvim/lua/plugins/grug_far.lua
@@ -10,5 +10,19 @@ return {
   end,
   keys = {
     { "\\", "<cmd>GrugFar<CR>", { noremap = true } },
+    {
+      "{",
+      function()
+        local grug = require('grug-far')
+        grug.open({
+          prefills = {
+            -- search = "word"
+            search = vim.fn.expand("<cword>")
+          }
+        })
+      end,
+      mode = { "n", "v" },
+      desc = "Search for word under cursor",
+    },
   },
 }


### PR DESCRIPTION
When trying to assign a shortcut to Grug Far word under cursor, a nil error is returned. `search` value can be replaced with "it doesn't matter" with the same results

![image](https://github.com/user-attachments/assets/0563c357-4df4-4d48-910b-faa066bb50f8)

Testing config in NeoVim using `:` 
`:lua require('grug-far').open({ prefills = { search = vim.fn.expand("<cword>") } })`

